### PR TITLE
cursor is a parameter, not a header

### DIFF
--- a/src/DropboxRestAPI/RequestsGenerators/Core/MetadataRequestGenerator.cs
+++ b/src/DropboxRestAPI/RequestsGenerators/Core/MetadataRequestGenerator.cs
@@ -135,7 +135,7 @@ namespace DropboxRestAPI.RequestsGenerators.Core
                 };
             request.AddHeader(Consts.AsTeamMemberHeader, asTeamMember);
 
-            request.AddHeader("cursor", cursor);
+            request.AddParameter("cursor", cursor);
             request.AddHeader("locale", locale);
             request.AddParameter("path_prefix", path_prefix);
             if (include_media_info)


### PR DESCRIPTION
The delta API isn't working correctly, as dropbox is ignoring the cursor header. It seems to work when this is switched to a parameter (as per the documentation).