### PR TITLE
`Metadata.SharedFoldersAsync` returns the Model, not the service

### DIFF
--- a/src/DropboxRestAPI/Services/Core/IMetadata.cs
+++ b/src/DropboxRestAPI/Services/Core/IMetadata.cs
@@ -361,6 +361,6 @@ namespace DropboxRestAPI.Services.Core
         /// <returns>
         /// A list of shared folders metadata objects, or the metadata for a specific shared folder if the id parameter is specified.
         /// </returns>
-        Task<IEnumerable<Metadata>> SharedFoldersAsync(string id = null, string asTeamMember = null);
+        Task<IEnumerable<MetaData>> SharedFoldersAsync(string id = null, string asTeamMember = null);
     }
 }

--- a/src/DropboxRestAPI/Services/Core/Metadata.cs
+++ b/src/DropboxRestAPI/Services/Core/Metadata.cs
@@ -190,9 +190,9 @@ namespace DropboxRestAPI.Services.Core
             return await _requestExecuter.Execute<MetaData>(() => _requestGenerator.CommitChunkedUpload(_options.Root, path, uploadId, locale, overwrite, parent_rev, autorename, asTeamMember)).ConfigureAwait(false);
         }
 
-        public async Task<IEnumerable<Metadata>> SharedFoldersAsync(string id = null, string asTeamMember = null)
+        public async Task<IEnumerable<MetaData>> SharedFoldersAsync(string id = null, string asTeamMember = null)
         {
-            return await _requestExecuter.Execute<IEnumerable<Metadata>>(() => _requestGenerator.SharedFolders(id, asTeamMember)).ConfigureAwait(false);
+            return await _requestExecuter.Execute<IEnumerable<MetaData>>(() => _requestGenerator.SharedFolders(id, asTeamMember)).ConfigureAwait(false);
         }
 
         #endregion


### PR DESCRIPTION
I guess it was just a typo because the service (`Metadata`) and the model (`MetaData`) are named almost identically.