### PR TITLE
Added more context to errors for easier troubleshooting.

### DIFF
--- a/src/DropboxRestAPI/Models/Error.cs
+++ b/src/DropboxRestAPI/Models/Error.cs
@@ -28,5 +28,6 @@ namespace DropboxRestAPI.Models
     public class Error
     {
         public string error { get; set; }
+        public string error_description { get; set; }
     }
 }

--- a/src/DropboxRestAPI/RequestExecuter.cs
+++ b/src/DropboxRestAPI/RequestExecuter.cs
@@ -134,7 +134,11 @@ namespace DropboxRestAPI
                 if (errorInfo == null || errorInfo.error == null)
                     throw new HttpException((int) statusCode, content) {Attempts = 1};
 
-                throw new ServiceErrorException((int) statusCode, errorInfo.error);
+                string error = errorInfo.error;
+                if (!string.IsNullOrEmpty(errorInfo.error_description))
+                    error = string.Format("{0}: {1}", errorInfo.error, errorInfo.error_description);
+
+                throw new ServiceErrorException((int)statusCode, error);
             }
             if (statusCode == HttpStatusCode.InternalServerError ||
                 statusCode == HttpStatusCode.BadGateway)


### PR DESCRIPTION
I noticed when implementing this that I was getting a weird error from DropBox. The error_description that is returned from DropBox would have saved me much time during troubleshooting. I would have figured out pretty quickly that it was user error on my end.