### PR TITLE
Fix for improper casing of some parameters when fetch OAuth Redirect URI

### DIFF
--- a/src/DropboxRestAPI/RequestsGenerators/Core/OAuthRequestGenerator.cs
+++ b/src/DropboxRestAPI/RequestsGenerators/Core/OAuthRequestGenerator.cs
@@ -44,9 +44,9 @@ namespace DropboxRestAPI.RequestsGenerators.Core
             request.AddParameter("redirect_uri", redirect_uri);
             request.AddParameter("state", state);
             if (force_reapprove)
-                request.AddParameter("force_reapprove", true.ToString());
+                request.AddParameter("force_reapprove", "true");
             if (disable_signup)
-                request.AddParameter("disable_signup", true.ToString());
+                request.AddParameter("disable_signup", "true");
 
             return request;
         }


### PR DESCRIPTION
Fixes issue #17 by explicitly using the lowercase string "true" for the REST API parameters, rather than the string version of true (which is "True")